### PR TITLE
Fix for NullPointerException due to null account id

### DIFF
--- a/InMobi/src/main/java/com/applovin/mediation/adapters/InMobiMediationAdapter.java
+++ b/InMobi/src/main/java/com/applovin/mediation/adapters/InMobiMediationAdapter.java
@@ -157,6 +157,12 @@ public class InMobiMediationAdapter
 
             status = InitializationStatus.INITIALIZING;
 
+            if (accountId == null) {
+                status = InitializationStatus.INITIALIZED_FAILURE;
+                onCompletionListener.onCompletion( status, "Adapter received null account id" );
+                return;
+            }
+
             final JSONObject consentObject = getConsentJSONObject( parameters );
 
             Runnable initializeSdkRunnable = new Runnable()


### PR DESCRIPTION
Fix for the issue where the adapter was getting null account id from AppLovin MAX SDK. 

- Added a check that dismisses the initialisation process if the account id is null. 